### PR TITLE
added rrd_xport

### DIFF
--- a/spec/rrd/wrapper_spec.rb
+++ b/spec/rrd/wrapper_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 describe RRD::Wrapper do
   
+  NaN = 0/0.0
+  
   context "when looking for librrd path" do
     before :each do
       Object.send(:remove_const, :RRD_LIB) if defined?(::RRD_LIB) 
@@ -52,6 +54,12 @@ describe RRD::Wrapper do
     it "should fetch values" do
       values = RRD::Wrapper.fetch(RRD_FILE, "AVERAGE", "--start", "1266933600", "--end", "1267020000")
       values.size.should == `rrdtool fetch #{RRD_FILE} AVERAGE --start 1266933600 --end 1267020000 | wc -l`.to_i - 1
+    end
+    
+    it 'should xport values' do
+      values = RRD::Wrapper.xport("--start", "1266933600", "--end", "1266944400", "DEF:xx=#{RRD_FILE}:cpu0:AVERAGE", "XPORT:xx:Legend 0")
+      values.should == [["time", "Legend 0"], [1266933600, 0.0008], [1266937200, 0.0008], [1266940800, 0.0008], [1266944400, NaN]]
+      
     end
     
     it "should return info data about this file" do


### PR DESCRIPTION
I added the function with its test, the test itself is failing but I don't understand why (and I don't use rspec):

  1) RRD::Wrapper when there is a rrd file should xport values
     Failure/Error: values.should == [["time", "Legend 0"], [1266933600, 0.0008], [1266937200, 0.0008], [1266940800, 0.0008], [1266944400, NaN]]
       expected: [["time", "Legend 0"], [1266933600, 0.0008], [1266937200, 0.0008], [1266940800, 0.0008], [1266944400, NaN]]
            got: [["time", "Legend 0"], [1266933600, 0.0008], [1266937200, 0.0008], [1266940800, 0.0008], [1266944400, NaN]](using ==)
       Diff:
     # ./spec/rrd/wrapper_spec.rb:61:in `block (3 levels) in <top (required)>'
