### PR TITLE
Add :extras option to RRD::Graph#draw to allow user to specify dashes, etc

### DIFF
--- a/lib/rrd/graph.rb
+++ b/lib/rrd/graph.rb
@@ -101,6 +101,10 @@ module RRD
         printable += ":#{options[:label]}"
       end
 
+      if options[:extra]
+        printable += ":#{options[:extra]}"
+      end
+
       printables << printable
       printable
     end

--- a/spec/rrd/graph_spec.rb
+++ b/spec/rrd/graph_spec.rb
@@ -28,9 +28,14 @@ describe RRD::Graph do
     result.should == "LINE1:mem#0000FF:Memory"
   end
   
-  it "should store printable for line drawing withou label" do
+  it "should store printable for line drawing without label" do
     result = @graph.draw_line :data => "mem", :color => "#0000FF", :width => 1
     result.should == "LINE1:mem#0000FF"
+  end
+  
+  it "should store printable for line drawing with extra" do
+    result = @graph.draw_line :data => "mem", :color => "#0000FF", :label => "Memory", :width => 1, :extra => "dashes=15,10,10,15"
+    result.should == "LINE1:mem#0000FF:Memory:dashes=15,10,10,15"
   end
   
   it "should store printable for area drawing" do

--- a/spec/rrd_spec.rb
+++ b/spec/rrd_spec.rb
@@ -36,7 +36,7 @@ describe RRD do
       for_rrd_data "mem", :memory => :average, :from => RRD_FILE #TODO: :start => Time.now - 1.day, :end => Time.now, :shift => 1.hour
       using_calculated_data "half_mem", :calc => "mem,2,/"
       using_value "mem_avg", :calc => "mem,AVERAGE"
-      draw_line :data => "mem", :color => "#0000FF", :label => "Memory: Average", :width => 1
+      draw_line :data => "mem", :color => "#0000FF", :label => "Memory: Average", :width => 1, :extra => "dashes"
       draw_area :data => "cpu0", :color => "#00FF00", :label => "CPU 0"
       print_comment "Information - "
       print_value "mem_avg", :format => "%6.2lf %SB"


### PR DESCRIPTION
Aside from using the raw wrapper, there is no way to draw graphs with dashed lines.  I added this :extras option to allow that, and any other options that can follow the label.  It does not gsub for :, so it lets you do more advanced things like "dashes=15,5,5,10:dash-offset=10"  (from example here http://oss.oetiker.ch/rrdtool/doc/rrdgraph_examples.en.html ).
