### PR TITLE
Allow graphing of negative values

### DIFF
--- a/lib/rrd/builder.rb
+++ b/lib/rrd/builder.rb
@@ -17,8 +17,9 @@ module RRD
     end
     
     def datasource(name, options = {})
-      options = {:type => :gauge, :heartbeat => 10.minutes, :min => 0, :max => :unlimited}.merge options
+      options = {:type => :gauge, :heartbeat => 10.minutes, :min => :unlimited, :max => :unlimited}.merge options
       options[:max] = "U" if options[:max] == :unlimited
+      options[:min] = "U" if options[:min] == :unlimited
       datasource = "DS:#{name}:#{options[:type].to_s.upcase}:#{options[:heartbeat]}:#{options[:min]}:#{options[:max]}"
       datasources << datasource
       datasource


### PR DESCRIPTION
By default negative values are not allowed in the datasources because the lower limit is set to 0. I have modified this to allow negative values.
